### PR TITLE
Updated service methods to return ApiResponseDto instead of JourneyDto list

### DIFF
--- a/DCXAir.API/Application/DTOs/ApiResponseDto.cs
+++ b/DCXAir.API/Application/DTOs/ApiResponseDto.cs
@@ -1,0 +1,11 @@
+﻿namespace DCXAir.API.Application.DTOs
+{
+    public class ApiResponseDto
+    {
+        public string Origin { get; set; }
+        public string Destination { get; set; }
+        public string Currency { get; set; }
+        public int TotalRoutes { get; set; }
+        public List<JourneyDto> Journeys { get; set; } = new();
+    }
+}

--- a/DCXAir.API/Application/Interfaces/IJourneyService.cs
+++ b/DCXAir.API/Application/Interfaces/IJourneyService.cs
@@ -3,8 +3,8 @@
     using DCXAir.API.Application.DTOs;
     public interface IJourneyService
     {
-        List<JourneyDto> GetFligths(string origin, string destination,string type, string currency);
-        List<JourneyDto> GetOneWayFlights(string origin, string destination, string type, string currency);
-        List<JourneyDto> GetRoundTripFlights(string origin, string destination,string type, string currency);
+        ApiResponseDto GetFligths(string origin, string destination,string type, string currency);
+        ApiResponseDto GetOneWayFlights(string origin, string destination, string type, string currency);
+        ApiResponseDto GetRoundTripFlights(string origin, string destination,string type, string currency);
     }
 }

--- a/DCXAir.API/markets.json
+++ b/DCXAir.API/markets.json
@@ -10,15 +10,6 @@
 	},
 	{
 		"Origin": "MZL",
-		"Destination": "BOG",
-		"Price": 1500.0,
-		"Transport": {
-			"FlightCarrier": "AV",
-			"FlightNumber": "8021"
-		}
-	},
-	{
-		"Origin": "MZL",
 		"Destination": "PEI",
 		"Price": 1000.0,
 		"Transport": {


### PR DESCRIPTION
- Refactored `JourneyService` methods to return `ApiResponseDto`, which includes additional information such as `Origin`, `Destination`, `Currency`, `TotalRoutes`, and a list of `JourneyDto` for the flights.
- Methods `GetOneWayFlights`, `GetRoundTripFlights`, and `GetFligths` were modified to return `ApiResponseDto` with the journey details.